### PR TITLE
Update deprecated API usage AnnotationHolder.createInfoAnnotation

### DIFF
--- a/src/main/kotlin/name/kropp/intellij/makefile/MakefileAnnotator.kt
+++ b/src/main/kotlin/name/kropp/intellij/makefile/MakefileAnnotator.kt
@@ -3,6 +3,7 @@ package name.kropp.intellij.makefile
 import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.Annotator
+import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 import com.intellij.psi.impl.source.resolve.reference.impl.providers.FileReference
@@ -15,14 +16,16 @@ class MakefileAnnotator : Annotator {
 
   override fun annotate(element: PsiElement, holder: AnnotationHolder) {
     if (element is MakefileRule && element.isUnused()) {
-      holder.createInfoAnnotation(element, "Redundant rule").apply {
-        highlightType = ProblemHighlightType.LIKE_UNUSED_SYMBOL
-        registerFix(RemoveRuleFix(element))
-      }
+      holder.newAnnotation(HighlightSeverity.INFORMATION, "Redundant rule").range(element)
+              .highlightType(ProblemHighlightType.LIKE_UNUSED_SYMBOL)
+              .withFix(RemoveRuleFix(element)).create()
     } else if (element is MakefileTarget && !(element.parent.parent.parent as MakefileRule).isUnused()) {
-      holder.createInfoAnnotation(element, null).textAttributes = if (element.isSpecialTarget) MakefileSyntaxHighlighter.SPECIAL_TARGET else MakefileSyntaxHighlighter.TARGET
+      holder.newSilentAnnotation(HighlightSeverity.INFORMATION).range(element)
+              .textAttributes(if (element.isSpecialTarget) MakefileSyntaxHighlighter.SPECIAL_TARGET else MakefileSyntaxHighlighter.TARGET)
+              .create()
     } else if (element is MakefilePrerequisite) {
-      holder.createInfoAnnotation(element, null).textAttributes = MakefileSyntaxHighlighter.PREREQUISITE
+      holder.newSilentAnnotation(HighlightSeverity.INFORMATION).range(element)
+              .textAttributes(MakefileSyntaxHighlighter.PREREQUISITE).create()
 
       if (Regex("""\$\((.*)\)""").matches(element.text)) {
         return
@@ -55,13 +58,16 @@ class MakefileAnnotator : Annotator {
         }
       }
     } else if (element is MakefileVariable) {
-      holder.createInfoAnnotation(element, null).textAttributes = MakefileSyntaxHighlighter.VARIABLE
+      holder.newSilentAnnotation(HighlightSeverity.INFORMATION).range(element)
+              .textAttributes(MakefileSyntaxHighlighter.VARIABLE).create()
     } else if (element is MakefileVariableValue) {
       element.node.getChildren(lineTokenSet).forEach {
-        holder.createInfoAnnotation(it, null).textAttributes = MakefileSyntaxHighlighter.VARIABLE_VALUE
+        holder.newSilentAnnotation(HighlightSeverity.INFORMATION).range(it)
+                .textAttributes(MakefileSyntaxHighlighter.VARIABLE_VALUE).create()
       }
     } else if (element is MakefileFunction) {
-      holder.createInfoAnnotation(element.firstChild, null).textAttributes = MakefileSyntaxHighlighter.FUNCTION
+      holder.newSilentAnnotation(HighlightSeverity.INFORMATION).range(element.firstChild)
+              .textAttributes(MakefileSyntaxHighlighter.FUNCTION).create()
     }
   }
 


### PR DESCRIPTION
### Description

JetBrains Annotations are now created using builders, updated internal usage to match that.

I would like to add that there are no instructions on what needs to be set up in order to execute tests. Upon attempting to execute them, I receive errors on all files specifying `Cannot find source file: /testData/completion/targets.mk; test data path: testData`. Is there something I need to add for execution?

- Relevant Issues : #5 

- What Changed and Why? :

## Types of changes

- Type of change :
  - [ ] New feature
  - [ ] Bug fix
  - [x] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation

## Checklist

- [ ] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.