### PR TITLE
Fixes #20. Update usage of deprecated Gradle features

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
 
     repositories {
         mavenCentral()
-        maven { url 'http://dl.bintray.com/jetbrains/intellij-plugin-service' }
+        maven { url 'https://dl.bintray.com/jetbrains/intellij-plugin-service' }
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
@@ -60,17 +60,18 @@ jar {
     }
 
     from {
-        configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }
+        configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
     }
 }
 
 
 dependencies {
     compileProcessBuilder
-    compile "com.fasterxml.jackson.core:jackson-core:2.9.9"
-    compile "com.fasterxml.jackson.core:jackson-databind:2.9.9"
+    implementation "com.fasterxml.jackson.core:jackson-core:2.9.9"
+    implementation "com.fasterxml.jackson.core:jackson-core:2.9.9"
+    implementation "com.fasterxml.jackson.core:jackson-databind:2.9.9"
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    testCompile "org.hamcrest:hamcrest-all:1.3"
+    testImplementation "org.hamcrest:hamcrest-all:1.3"
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,6 @@ jar {
 dependencies {
     compileProcessBuilder
     implementation "com.fasterxml.jackson.core:jackson-core:2.9.9"
-    implementation "com.fasterxml.jackson.core:jackson-core:2.9.9"
     implementation "com.fasterxml.jackson.core:jackson-databind:2.9.9"
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     testImplementation "org.hamcrest:hamcrest-all:1.3"


### PR DESCRIPTION
### Description

Gradle requires the use of HTTPS.
The `compile` keyword has been replaced with `implementation`.
Since we are collecting the file structure, use `runtimeClasspath`.

Please note that it is difficult for me to test these changes as tests are currently failing, causing a build failure.

- Relevant Issues : #20 

- What Changed and Why? :

## Types of changes

- Type of change :
  - [ ] New feature
  - [ ] Bug fix
  - [x] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation

## Checklist

- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.