### PR TITLE
Fix Class constructor must not have parameters #24

### DIFF
--- a/src/main/kotlin/com/intuit/ddb/DockDockBuildConfigurable.kt
+++ b/src/main/kotlin/com/intuit/ddb/DockDockBuildConfigurable.kt
@@ -12,8 +12,9 @@ import javax.swing.JComponent
 import javax.swing.JTextField
 
 // Docker Make project config
-class DockDockBuildConfigurable(project: Project?, private val settings: DockDockBuildProjectSettings) : Configurable {
+class DockDockBuildConfigurable(project: Project?) : Configurable {
 
+    private val settings = DockDockBuildProjectSettings()
     private val dockerPathField = TextFieldWithBrowseButton()
     private val codePathField = TextFieldWithBrowseButton()
     private val mavenCachePathField = TextFieldWithBrowseButton()


### PR DESCRIPTION
### Description
Fix Class constructor must not have parameters #24

Please describe your changes in detail.

- Relevant Issues : 

- What Changed and Why? :

Below is the console output after making the change:

INTUL173c2a85e:DockDockBuild ssinaicuncoliencar$ ./gradlew buildPlugin

> Task :buildSearchableOptions
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.intellij.util.ReflectionUtil to field java.awt.event.InvocationEvent.runnable
WARNING: Please consider reporting this to the maintainers of com.intellij.util.ReflectionUtil
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
2020-10-05 19:46:43,050 [    760]   WARN - j.internal.DebugAttachDetector - Unable to start DebugAttachDetector, please add `--add-exports java.base/jdk.internal.vm=ALL-UNNAMED` to VM options 
Starting searchable options index builder
2020-10-05 19:46:43,529 [   1239]   WARN - ConfigurableExtensionPointUtil - ignore deprecated groupId: language for id: preferences.language.Kotlin.scripting 
2020-10-05 19:46:44,029 [   1739]   WARN - nSystem.impl.ActionManagerImpl - keymap "Xcode" not found [Plugin: com.intellij] 
Searchable options index builder completed

BUILD SUCCESSFUL in 17s
12 actionable tasks: 4 executed, 8 up-to-date


## Types of changes

- Type of change :
  - [ ] New feature
  - [x] Bug fix
  - [ ] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation

## Checklist

- [ ] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.