### PR TITLE
Replace PluginClassLoader with UrlClassLoader

### DIFF
--- a/src/main/kotlin/com/intuit/ddb/conf/DockDockBuildRunConfiguration.kt
+++ b/src/main/kotlin/com/intuit/ddb/conf/DockDockBuildRunConfiguration.kt
@@ -8,10 +8,10 @@ import com.intellij.execution.process.ColoredProcessHandler
 import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.process.ProcessTerminatedListener
 import com.intellij.execution.runners.ExecutionEnvironment
-import com.intellij.ide.plugins.cl.PluginClassLoader
 import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.project.Project
 import com.intellij.util.getOrCreate
+import com.intellij.util.lang.UrlClassLoader
 import com.intuit.ddb.* // ktlint-disable no-wildcard-imports
 import org.jdom.Element
 import java.io.File
@@ -140,12 +140,12 @@ open class DockDockBuildRunConfiguration(project: Project, factoryDocker: DockDo
         objectMapper.writeValue(File(getParamsFile(project)), cmdParams)
     }
 
-    // iterate over IntelliJ's PluginClassLoader and find DockDockBuild.jar classpath to call CmdProcessBuilder
+    // iterate over IntelliJ's UrlClassLoader and find DockDockBuild.jar classpath to call CmdProcessBuilder
     private fun getClassPath(): String {
         val jarRegex = Regex("DockDockBuild.jar")
         var classpath = ""
 
-        for (cp in (CmdProcessBuilder::class.java.classLoader as PluginClassLoader).urls) {
+        for (cp in (CmdProcessBuilder::class.java.classLoader as UrlClassLoader).urls) {
             if (jarRegex.containsMatchIn(cp.file)) {
                 classpath = cp.path
                 break


### PR DESCRIPTION
### Description

Changed Intellij's PluginClassLoader to UrlClassLoader, since PluginClassLoader class has been marked as @ApiStatus.Internal

- Relevant Issues : #36 

- What Changed and Why? :
Intellij's PluginClassLoader class has been marked as @ApiStatus.Internal as of Intellij version 2021.1.1. So we replaced it with the parent class UrlClassLoader

## Types of changes

- Type of change :
   - [ ] New feature
   - [x] Bug fix
   - [ ] Code quality improvement
   - [ ] Addition or Improvement of tests
   - [ ] Addition or Improvement of documentation


## Checklist

- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.