### PR TITLE
Fix usage of deprecated method - ServiceManager.getService(Project, Class)

### DIFF
--- a/src/main/kotlin/com/intuit/ddb/conf/DockDockBuildRunConfiguration.kt
+++ b/src/main/kotlin/com/intuit/ddb/conf/DockDockBuildRunConfiguration.kt
@@ -8,7 +8,6 @@ import com.intellij.execution.process.ColoredProcessHandler
 import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.process.ProcessTerminatedListener
 import com.intellij.execution.runners.ExecutionEnvironment
-import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.project.Project
 import com.intellij.util.getOrCreate
 import com.intellij.util.lang.UrlClassLoader

--- a/src/main/kotlin/com/intuit/ddb/conf/DockDockBuildRunConfiguration.kt
+++ b/src/main/kotlin/com/intuit/ddb/conf/DockDockBuildRunConfiguration.kt
@@ -114,13 +114,13 @@ open class DockDockBuildRunConfiguration(project: Project, factoryDocker: DockDo
     private fun handleParams() {
 
         // Plugin (project) configuration
-        val dockerPath = ServiceManager.getService(project, DockDockBuildProjectSettings::class.java)
+        val dockerPath = project.getService(DockDockBuildProjectSettings::class.java)
             .settings.dockerPath
-        val codePath = ServiceManager.getService(project, DockDockBuildProjectSettings::class.java)
+        val codePath = project.getService(DockDockBuildProjectSettings::class.java)
             .settings.codePath
-        val m2Path = ServiceManager.getService(project, DockDockBuildProjectSettings::class.java)
+        val m2Path = project.getService(DockDockBuildProjectSettings::class.java)
             .settings.mavenCachePath
-        val advancedDockerSettings = ServiceManager.getService(project, DockDockBuildProjectSettings::class.java)
+        val advancedDockerSettings = project.getService(DockDockBuildProjectSettings::class.java)
             .settings.advancedDockerSettings
 
         // Runtime configurations


### PR DESCRIPTION
### Description

Please describe your changes in detail.

- Relevant Issues : #50 

- What Changed and Why? : I made changes to the handleParams() function in DockDockBuildRunConfiguration.kt to fix the usage of the deprecated method, `ServiceManager.getService(Projcet, Class)`. The updated way to do this is just `Project.getService(Class)` as seen [here](https://github.com/JetBrains/intellij-community/blob/master/platform/core-api/src/com/intellij/openapi/components/ServiceManager.java).

## Types of changes

- Type of change :
  - [ ] New feature
  - [ ] Bug fix
  - [x] Code quality improvement
  - [ ] Addition or Improvement of tests
  - [ ] Addition or Improvement of documentation

## Checklist

- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.